### PR TITLE
Add METHOD_ELF static const

### DIFF
--- a/risc0/zkvm/sdk/rust/build/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/build/src/lib.rs
@@ -90,10 +90,12 @@ impl Risc0Method {
         let elf_path = self.elf_path.display();
         let upper = self.name.to_uppercase();
         let method_id = self.make_method_id(code_limit);
+        let elf_contents = std::fs::read(&self.elf_path).unwrap();
         format!(
             r##"
 pub const {upper}_PATH: &'static str = r#"{elf_path}"#;
 pub const {upper}_ID: &'static [u8] = &{method_id:?};
+pub const {upper}_ELF: &'static [u8] = &{elf_contents:?};            
             "##
         )
     }


### PR DESCRIPTION
Currently, prover have a hard link to guest's elf files, which is inconvenient for deployment. This PR makes it possible that prover can embedded the guest's elf content and running alone.